### PR TITLE
Don't clobber ContentType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "curs"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Nubis <yo@nubis.im>"]
 description = "Hyper HTTP client lib, feels more like curl. Supports file Uploads."
 repository = "https://github.com/bitex-la/rust-curs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //! use curs::{Request, FileUpload, DecodableResult, Method};
 //!
 //! // Just stuff needed for this particular test.
-//! extern crate http_stub; 
+//! extern crate http_stub;
 //! use http_stub as hs;
 //! use std::env;
 //! use curs::hyper::header::UserAgent;
@@ -67,52 +67,52 @@ use self::hyper::mime::Mime;
 
 /// Your result may be text or a struct deserialized from JSON.
 /// The error is always a CursError
-pub type CursResult<T> = Result<T,CursError>;
+pub type CursResult<T> = Result<T, CursError>;
 
 pub trait DecodableResult {
-  fn decode_success<D: Deserialize>(self) -> CursResult<D>;
+    fn decode_success<D: Deserialize>(self) -> CursResult<D>;
 }
 
 impl DecodableResult for CursResult<Response> {
-  /// You can chain a decode_success call to your CursResult
-  /// to deserialize a successful (2xx) JSON response. Using serde.
-  fn decode_success<D: Deserialize>(self) -> CursResult<D> {
-    let mut response = try!(self);
-    match response.status {
-      StatusCode::Ok | StatusCode::Created | StatusCode::Accepted => {
-        let mut response_string = String::new();
-        try!(response.read_to_string(&mut response_string));
-        Ok(try!(serde_json::from_str(&response_string)))
-      },
-      _ => Err(CursError::Status(response))
+    /// You can chain a decode_success call to your CursResult
+    /// to deserialize a successful (2xx) JSON response. Using serde.
+    fn decode_success<D: Deserialize>(self) -> CursResult<D> {
+        let mut response = try!(self);
+        match response.status {
+            StatusCode::Ok | StatusCode::Created | StatusCode::Accepted => {
+                let mut response_string = String::new();
+                try!(response.read_to_string(&mut response_string));
+                Ok(try!(serde_json::from_str(&response_string)))
+            }
+            _ => Err(CursError::Status(response)),
+        }
     }
-  }
 }
 
 /// Sending your request may fail for any of the following reasons.
 #[derive(Debug)]
 pub enum CursError {
-  Status(Response),
-  Network(HyperError),
-  Json(serde_json::Error)
+    Status(Response),
+    Network(HyperError),
+    Json(serde_json::Error),
 }
 
 impl From<HyperError> for CursError {
-  fn from(err: HyperError) -> CursError {
-    CursError::Network(err)
-  }
+    fn from(err: HyperError) -> CursError {
+        CursError::Network(err)
+    }
 }
 
 impl From<IoError> for CursError {
-  fn from(i: IoError) -> CursError {
-    CursError::Network(HyperError::Io(i))
-  }
+    fn from(i: IoError) -> CursError {
+        CursError::Network(HyperError::Io(i))
+    }
 }
 
 impl From<serde_json::Error> for CursError {
-  fn from(err: serde_json::Error) -> CursError {
-    CursError::Json(err)
-  }
+    fn from(err: serde_json::Error) -> CursError {
+        CursError::Json(err)
+    }
 }
 
 /// All your params should go in a vector.
@@ -124,9 +124,9 @@ pub type Param<'a> = (&'a str, &'a str);
 /// File uploads are more than just a path to a local file.
 #[derive(Clone)]
 pub struct FileUpload<'a> {
-  pub name: String,
-  pub mime: Option<Mime>,
-  pub path: &'a Path
+    pub name: String,
+    pub mime: Option<Mime>,
+    pub path: &'a Path,
 }
 
 /// You're not expected to be using the MultipartBodyBuilder on your own,
@@ -134,8 +134,8 @@ pub struct FileUpload<'a> {
 /// to be posted. It's still exported publicly because it may come in handy
 /// for other uses.
 pub struct MultipartBodyBuilder {
-  body: Vec<u8>,
-  boundary: String
+    body: Vec<u8>,
+    boundary: String,
 }
 
 macro_rules! w {
@@ -145,109 +145,120 @@ macro_rules! w {
 }
 
 impl MultipartBodyBuilder {
-  pub fn new() -> MultipartBodyBuilder {
-    let mut rng = rand::thread_rng();
-    let boundary: String = rng.gen_ascii_chars().take(30).collect();
-    MultipartBodyBuilder{ body: vec![], boundary: boundary }
-  }
-
-  pub fn build<'a>(mut self, files: Vec<FileUpload>, params: Params<'a>)
-    -> Result<MultipartBodyBuilder, CursError> 
-  {
-    for (name, value) in params {
-      w!(self, "\r\n--{}\r\n", self.boundary);
-      w!(self, "Content-Disposition: form-data; name=\"{}\"", name);
-      w!(self, "\r\n{}\r\n", value);
+    pub fn new() -> MultipartBodyBuilder {
+        let mut rng = rand::thread_rng();
+        let boundary: String = rng.gen_ascii_chars().take(30).collect();
+        MultipartBodyBuilder {
+            body: vec![],
+            boundary: boundary,
+        }
     }
 
-    for FileUpload{ name, path, mime } in files {
-      w!(self, "\r\n--{}\r\n", self.boundary);
-      w!(self, "Content-Disposition: form-data; name=\"{}\"", name);
-      w!(self, "; filename=\"{}\"", path.file_name().unwrap().to_str().unwrap());
-      w!(self, "\r\nContent-Type: {}\r\n\r\n",
-        mime.unwrap_or_else(|| self::mime_guess::guess_mime_type(path)));
+    pub fn build<'a>(mut self,
+                     files: Vec<FileUpload>,
+                     params: Params<'a>)
+                     -> Result<MultipartBodyBuilder, CursError> {
+        for (name, value) in params {
+            w!(self, "\r\n--{}\r\n", self.boundary);
+            w!(self, "Content-Disposition: form-data; name=\"{}\"", name);
+            w!(self, "\r\n{}\r\n", value);
+        }
 
-      let mut contents = try!(File::open(path));
-      try!(contents.read_to_end(&mut self.body));
-      self.body.extend("\r\n\r\n".as_bytes());
+        for FileUpload { name, path, mime } in files {
+            w!(self, "\r\n--{}\r\n", self.boundary);
+            w!(self, "Content-Disposition: form-data; name=\"{}\"", name);
+            w!(self,
+               "; filename=\"{}\"",
+               path.file_name().unwrap().to_str().unwrap());
+            w!(self,
+               "\r\nContent-Type: {}\r\n\r\n",
+               mime.unwrap_or_else(|| self::mime_guess::guess_mime_type(path)));
+
+            let mut contents = try!(File::open(path));
+            try!(contents.read_to_end(&mut self.body));
+            self.body.extend("\r\n\r\n".as_bytes());
+        }
+
+        w!(self, "\r\n--{}--", self.boundary);
+
+        Ok(self)
     }
-      
-    w!(self, "\r\n--{}--", self.boundary);
-
-    Ok(self)
-  }
 }
 
 /// The main entry point. Craft your request and send it.
 #[derive(Clone)]
 pub struct Request<'a> {
-  method: Method,
-  url: &'a str,
-  params: Params<'a>,
-  headers: Headers,
-  files: Vec<FileUpload<'a>>
+    method: Method,
+    url: &'a str,
+    params: Params<'a>,
+    headers: Headers,
+    files: Vec<FileUpload<'a>>,
 }
 
-impl<'a> Request<'a>{
-  /// You'll always need a method and the url to start.
-  pub fn new(method: Method, url: &'a str) -> Request<'a> {
-    Request{ method: method, url: url,
-      params: vec![], headers: Headers::new(), files: vec![] }
-  }
-
-  /// Add params. This extends the existing params vector.
-  pub fn params<P>(&mut self, additional: P) -> &mut Request<'a>
-    where P: IntoIterator<Item = Param<'a>>
-  {
-    self.params.extend(additional);
-    self
-  }
-
-  /// Add files to upload. This extends the existing files vector.
-  pub fn files<F>(&mut self, additional: F) -> &mut Request<'a>
-    where F: IntoIterator<Item = FileUpload<'a>>
-  {
-    self.files.extend(additional);
-    self
-  }
-
-  /// Add a single header.
-  pub fn header<H>(&mut self, additional: H) -> &mut Request<'a>
-    where H: Header + HeaderFormat
-  {
-    self.headers.set(additional);
-    self
-  }
-
-  /// Send your request and see what happens.
-  pub fn send(&self) -> CursResult<Response> {
-    let multipart_raw_body : Box<[u8]>; // We define it here for lifetime reasons.
-    let params_as_query = &*url::form_urlencoded::serialize(&self.params);
-    let mut url_string = self.url.into_url().unwrap().serialize();
-    if self.params.len() > 0 && (self.method == Method::Get || self.method == Method::Head)  {
-      url_string = [&*url_string, "?", params_as_query].concat()
+impl<'a> Request<'a> {
+    /// You'll always need a method and the url to start.
+    pub fn new(method: Method, url: &'a str) -> Request<'a> {
+        Request {
+            method: method,
+            url: url,
+            params: vec![],
+            headers: Headers::new(),
+            files: vec![],
+        }
     }
-    let client = Client::new();
-    let mut request = client
-      .request(self.method.clone(), &*url_string)
-      .headers(self.headers.clone());
 
-    if self.method != Method::Get && self.method != Method::Head {
-      request = if self.files.len() == 0 {
-        request
-          .header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
-          .body(params_as_query)
-      }else{
-        let builder =
-          try!(MultipartBodyBuilder::new()
-            .build(self.files.clone(), self.params.clone()));
-        let raw_mime = ["multipart/form-data; boundary=", &*builder.boundary].concat();
-        multipart_raw_body = builder.body.into_boxed_slice();
-        request
-          .header(ContentType(raw_mime.parse().unwrap()))
-          .body(&*multipart_raw_body)
-      }
-    };
-    Ok(try!(request.send()))
-  }
+    /// Add params. This extends the existing params vector.
+    pub fn params<P>(&mut self, additional: P) -> &mut Request<'a>
+        where P: IntoIterator<Item = Param<'a>>
+    {
+        self.params.extend(additional);
+        self
+    }
+
+    /// Add files to upload. This extends the existing files vector.
+    pub fn files<F>(&mut self, additional: F) -> &mut Request<'a>
+        where F: IntoIterator<Item = FileUpload<'a>>
+    {
+        self.files.extend(additional);
+        self
+    }
+
+    /// Add a single header.
+    pub fn header<H>(&mut self, additional: H) -> &mut Request<'a>
+        where H: Header + HeaderFormat
+    {
+        self.headers.set(additional);
+        self
+    }
+
+    /// Send your request and see what happens.
+    pub fn send(&self) -> CursResult<Response> {
+        let multipart_raw_body: Box<[u8]>; // We define it here for lifetime reasons.
+        let params_as_query = &*url::form_urlencoded::serialize(&self.params);
+        let mut url_string = self.url.into_url().unwrap().serialize();
+        if self.params.len() > 0 && (self.method == Method::Get || self.method == Method::Head) {
+            url_string = [&*url_string, "?", params_as_query].concat()
+        }
+        let client = Client::new();
+        let mut request = client.request(self.method.clone(), &*url_string)
+                                .headers(self.headers.clone());
+
+        // We don't want to clobber the user's ContentType if they specified one!
+        let has_type = self.headers.has::<ContentType>();
+
+        if self.method != Method::Get && self.method != Method::Head && !has_type {
+            request = if self.files.len() == 0 {
+                request.header(ContentType("application/x-www-form-urlencoded".parse().unwrap()))
+                       .body(params_as_query)
+            } else {
+                let builder = try!(MultipartBodyBuilder::new()
+                                       .build(self.files.clone(), self.params.clone()));
+                let raw_mime = ["multipart/form-data; boundary=", &*builder.boundary].concat();
+                multipart_raw_body = builder.body.into_boxed_slice();
+                request.header(ContentType(raw_mime.parse().unwrap()))
+                       .body(&*multipart_raw_body)
+            }
+        };
+        Ok(try!(request.send()))
+    }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,91 +6,120 @@ extern crate http_stub;
 extern crate serde;
 
 use std::env;
-use curs::hyper::header::UserAgent;
+use curs::hyper::header::{ContentType, UserAgent};
 use curs::hyper::method::Method;
+use curs::hyper::mime::{Mime, SubLevel, TopLevel};
 use curs::{Request, DecodableResult, CursResult, CursError, FileUpload};
 use http_stub::HttpStub;
 use http_stub as hs;
 
 #[derive(Deserialize, Debug, PartialEq)]
-struct DummyJson { foo: String }
-
-#[test]
-fn successful_multipart(){
-  let url = HttpStub::run(|mut stub|{
-    stub.got_path("/some_post");
-    stub.got_method(hs::Method::Post);
-    stub.got_header("content-type", "multipart/form-data; boundary");
-    stub.got_header("user-agent", "morcilla-firefox");
-    stub.got_body(r"Content-Type: image/png");
-    stub.got_body(r#"name="shim.png"; filename="test.png""#);
-    stub.got_body(r#"Content-Disposition: form-data; name="two"\r\nvalue_two\r\n"#);
-
-    stub.send_status(hs::StatusCode::Ok);
-    stub.send_header(hs::header::ContentType(
-      hs::Mime(hs::TopLevel::Application, hs::SubLevel::Json, vec![])));
-    stub.send_body(r#"{"foo":"got files"}"#);
-  });
-
-  let file = FileUpload{
-    name: "shim.png".to_string(),
-    mime: None,
-    path: &env::current_dir().unwrap().join("tests/fixtures/test.png")};
-
-  let response : DummyJson = Request::new(Method::Post, &*format!("{}/some_post", url))
-    .params(vec![("one","value_one"), ("two", "value_two")])
-    .header(UserAgent("morcilla-firefox".to_string()))
-    .files(vec![file])
-    .send().decode_success().unwrap();
-  assert_eq!(response, DummyJson{ foo: "got files".to_string() });
+struct DummyJson {
+    foo: String,
 }
 
 #[test]
-fn successful_json_get(){
-  let url = HttpStub::run(|stub|{
-    stub.got_path(r"/a_get\?one=value_one&two=value_two");
-    stub.got_body("");
-    stub.got_method(hs::Method::Get);
-    stub.got_header("user-agent", "morcilla-firefox");
-    stub.send_body(r#"{"foo":"bar"}"#);
-  });
+fn successful_multipart() {
+    let url = HttpStub::run(|mut stub| {
+        stub.got_path("/some_post");
+        stub.got_method(hs::Method::Post);
+        stub.got_header("content-type", "multipart/form-data; boundary");
+        stub.got_header("user-agent", "morcilla-firefox");
+        stub.got_body(r"Content-Type: image/png");
+        stub.got_body(r#"name="shim.png"; filename="test.png""#);
+        stub.got_body(r#"Content-Disposition: form-data; name="two"\r\nvalue_two\r\n"#);
 
-  let response : DummyJson = Request::new(Method::Get, &*format!("{}/a_get", url))
-    .params(vec![("one","value_one"), ("two", "value_two")])
-    .header(UserAgent("morcilla-firefox".to_string()))
-    .send().decode_success().unwrap();
-  assert_eq!(response, DummyJson{ foo: "bar".to_string() });
+        stub.send_status(hs::StatusCode::Ok);
+        stub.send_header(hs::header::ContentType(hs::Mime(hs::TopLevel::Application,
+                                                          hs::SubLevel::Json,
+                                                          vec![])));
+        stub.send_body(r#"{"foo":"got files"}"#);
+    });
+
+    let file = FileUpload {
+        name: "shim.png".to_string(),
+        mime: None,
+        path: &env::current_dir().unwrap().join("tests/fixtures/test.png"),
+    };
+
+    let response: DummyJson = Request::new(Method::Post, &*format!("{}/some_post", url))
+                                  .params(vec![("one", "value_one"), ("two", "value_two")])
+                                  .header(UserAgent("morcilla-firefox".to_string()))
+                                  .files(vec![file])
+                                  .send()
+                                  .decode_success()
+                                  .unwrap();
+    assert_eq!(response, DummyJson { foo: "got files".to_string() });
 }
 
 #[test]
-fn successful_json_post(){
-  let url = HttpStub::run(|stub|{
-    stub.got_path("/some_post");
-    stub.got_method(hs::Method::Post);
-    stub.got_body("one=value_one&two=value_two");
-    stub.send_body(r#"{"foo":"that"}"#);
-  });
+fn successful_json_get() {
+    let url = HttpStub::run(|stub| {
+        stub.got_path(r"/a_get\?one=value_one&two=value_two");
+        stub.got_body("");
+        stub.got_method(hs::Method::Get);
+        stub.got_header("user-agent", "morcilla-firefox");
+        stub.send_body(r#"{"foo":"bar"}"#);
+    });
 
-  let response : DummyJson = Request::new(Method::Post, &*format!("{}/some_post", url))
-    .params(vec![("one","value_one"), ("two", "value_two")])
-    .send().decode_success().unwrap();
-  assert_eq!(response, DummyJson{ foo: "that".to_string() });
+    let response: DummyJson = Request::new(Method::Get, &*format!("{}/a_get", url))
+                                  .params(vec![("one", "value_one"), ("two", "value_two")])
+                                  .header(UserAgent("morcilla-firefox".to_string()))
+                                  .send()
+                                  .decode_success()
+                                  .unwrap();
+    assert_eq!(response, DummyJson { foo: "bar".to_string() });
 }
 
 #[test]
-fn errors_out_with_not_found(){
-  let url = HttpStub::run(|mut stub|{
-    stub.got_body("");
-    stub.got_method(hs::Method::Get);
-    stub.send_status(hs::StatusCode::InternalServerError);
-    stub.send_body("404 not found");
-  });
+fn successful_json_post() {
+    let url = HttpStub::run(|stub| {
+        stub.got_path("/some_post");
+        stub.got_method(hs::Method::Post);
+        stub.got_body("one=value_one&two=value_two");
+        stub.send_body(r#"{"foo":"that"}"#);
+    });
 
-  let result : CursResult<DummyJson> =
-    Request::new(Method::Get, &*url).send().decode_success();
+    let response: DummyJson = Request::new(Method::Post, &*format!("{}/some_post", url))
+                                  .params(vec![("one", "value_one"), ("two", "value_two")])
+                                  .send()
+                                  .decode_success()
+                                  .unwrap();
+    assert_eq!(response, DummyJson { foo: "that".to_string() });
+}
 
-  match result.unwrap_err() {
-    CursError::Status(_) => { },
-    _ => panic!("No status error")
-  }
+#[test]
+fn post_with_alternate_content_type() {
+    let url = HttpStub::run(|stub| {
+        stub.got_path("/some_post");
+        stub.got_header("content-type", "application/json");
+        stub.got_method(hs::Method::Post);
+        stub.send_body(r#"{"foo":"that"}"#);
+    });
+
+    let response: DummyJson = Request::new(Method::Post, &*format!("{}/some_post", url))
+                                  .header(ContentType(Mime(TopLevel::Application,
+                                                           SubLevel::Json,
+                                                           vec![])))
+                                  .send()
+                                  .decode_success()
+                                  .unwrap();
+    assert_eq!(response, DummyJson { foo: "that".to_string() });
+}
+
+#[test]
+fn errors_out_with_not_found() {
+    let url = HttpStub::run(|mut stub| {
+        stub.got_body("");
+        stub.got_method(hs::Method::Get);
+        stub.send_status(hs::StatusCode::InternalServerError);
+        stub.send_body("404 not found");
+    });
+
+    let result: CursResult<DummyJson> = Request::new(Method::Get, &*url).send().decode_success();
+
+    match result.unwrap_err() {
+        CursError::Status(_) => {}
+        _ => panic!("No status error"),
+    }
 }


### PR DESCRIPTION
Currently, Request#send() will change the content-type for all non-GET or non-HEAD requests.

This is definitely desired behavior as it's convenient in most cases. However if the user specifies an alternate content-type (say, application/json for POST) it will be clobbered by either application/x-www-form-urlencoded or multipart/form-data.

This PR checks to see if the user has _already defined_ a content-type before deciding whether or not to use the aforementioned defaults.

Additionally, I ran rustfmt!
