### PR TITLE
Move serde_macro to dev dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ hyper = "0.7.2"
 url = "=0.5.5"
 serde = "0.7"
 serde_json = "0.7"
-serde_macros = "0.7.2"
 rand = "0.3.14"
 mime_guess = "=1.4.0"
 
 [dev-dependencies]
 http_stub = "0.1.2"
+serde_macros = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,10 @@
 //! }
 //! ```
 
-#![feature(custom_derive, plugin)]
-
 pub extern crate serde;
 pub extern crate serde_json;
 pub extern crate hyper;
+
 extern crate url;
 extern crate rand;
 extern crate mime_guess;


### PR DESCRIPTION
Since `custom_derive` was only used in tests and the lib only needed Deserialize and Serialize trait objects, I moved `serde_macros` to `[dev-dependencies]`. 

Works exactly as before but needs to build one less crate when pulled in.
